### PR TITLE
Adds middleware for persistent cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,53 @@ end
 cossack.get("http://example.org/redirect-me")
 ```
 
+### How to persist cookies between requests
+
+If, for example, you're calling an API that relies on cookies, you'll need to
+use the `CookieJarMiddleware` like so:
+
+```crystal
+cossack = Cossack::Client.new do |client|
+  # Other middleware goes here
+end
+cossack.use Cossack::CookieJarMiddleware, cookie_jar: cossack.cookies
+```
+
+Note that `cossack.use Cossack::CookieJarMiddleware` needs to be outside of the
+`do ... end` block due to problems in Crystal (as of v0.18.7)
+
+### How to persist cookies past the life of the application
+
+If, for example, you have a need to retain cookies you're already storing
+between requests, you have the option to write them out to a file using
+something like the following:
+
+```crystal
+cossack = Cossack::Client.new do |client|
+  # Other middleware goes here
+end
+cossack.use Cossack::CookieJarMiddleware, cookie_jar: cossack.cookies
+
+# [code]
+
+cossack.cookies.export_to_file("/path/to/writable/directory/cookies.txt")
+```
+
+You may also import the cookies like so:
+```crystal
+cossack = Cossack::Client.new do |client|
+  # Other middleware goes here
+end
+cossack.cookies.import_from_file("/path/to/writable/directory/cookies.txt")
+
+# OR
+
+cossack = Cossack::Client.new do |client|
+  client.cookies = Cossack::CookieJar.from_file("/path/to/writable/directory/cookies.txt")
+  # Other middleware goes here
+end
+```
+
 ## Development
 
 To run all tests:

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Cossack is inspired by [Faraday](https://github.com/lostisland/faraday) and [Hur
 
 The main things are: Client, Request, Response, Connection, Middleware.
 * **Client** - provides a convenient API to build and perform HTTP requests. Keeps default request parameters(base url, headers, request options, etc.)
-* **Request** - HTTP request(method, uri, headers, body) with its options (e.g. connect_timeout`).
+* **Request** - HTTP request(method, uri, headers, body) with its options (e.g. `connect_timeout`).
 * **Response** - HTTP response(method, headers, body).
 * **Connection** - executes actual Request, used by Client and can be subsituted (e.g. for test purposes).
 * **Middleware** - can be injected between Client and Connection to execute some custom stuff(e.g. logging, caching, etc.)
@@ -207,3 +207,4 @@ But first we need to get positive feedback to ensure we're moving in the right d
 ## Contributors
 
 - [greyblake](https://github.com/greyblake) Sergey Potapov - creator, maintainer
+- [thelonelyghost](https://github.com/thelonelyghost) David Alexander

--- a/spec/acceptance/cookie_jar_middleware_spec.cr
+++ b/spec/acceptance/cookie_jar_middleware_spec.cr
@@ -1,0 +1,36 @@
+require "../spec_helper"
+
+Spec2.describe "CookieJarMiddleware usage" do
+  let(client) do
+    client = Cossack::Client.new(TEST_SERVER_URL)
+    client.use Cossack::CookieJarMiddleware, cookie_jar: client.cookies
+    client
+  end
+
+  it "allows to register middleware" do
+    expect { client }.not_to raise_error
+  end
+
+  it "persists cookies between requests" do
+    expect(client.get("/cookie").body).to eq("No cookie found")
+    expect(client.cookies.empty?).to be_true
+
+    response = client.put("/cookie", "{ \"cookie\": \"test_cookie=works\" }") do |request|
+      request.headers["Content-Type"] = "application/json"
+    end
+    expect(response.headers["Set-Cookie"]?).not_to be_nil
+    expect(client.cookies.empty?).to be_false
+
+    expect(client.get("/cookie").body).to match(/^Cookie: /)
+  end
+
+  it "handles cookies added manually" do
+    expect(client.get("/cookie").body).to eq("No cookie found")
+    expect(client.cookies.empty?).to be_true
+
+    client.cookies << HTTP::Cookie.new("some_cookie", "some_value")
+
+    expect(client.cookies.empty?).to be_false
+    expect(client.get("/cookie").body).to match(/^Cookie: /)
+  end
+end

--- a/spec/acceptance/cookie_jar_middleware_spec.cr
+++ b/spec/acceptance/cookie_jar_middleware_spec.cr
@@ -21,7 +21,7 @@ Spec2.describe "CookieJarMiddleware usage" do
     expect(response.headers["Set-Cookie"]?).not_to be_nil
     expect(client.cookies.empty?).to be_false
 
-    expect(client.get("/cookie").body).to match(/^Cookie: /)
+    expect(client.get("/cookie").body).to match(/^Cookie: (?:.+;)?test_cookie=works(?:;.+|$)/)
   end
 
   it "handles cookies added manually" do
@@ -31,6 +31,6 @@ Spec2.describe "CookieJarMiddleware usage" do
     client.cookies << HTTP::Cookie.new("some_cookie", "some_value")
 
     expect(client.cookies.empty?).to be_false
-    expect(client.get("/cookie").body).to match(/^Cookie: /)
+    expect(client.get("/cookie").body).to match(/^Cookie: (?:.+;)?some_cookie=some_value(?:;.+|$)/)
   end
 end

--- a/spec/support/server.cr
+++ b/spec/support/server.cr
@@ -37,12 +37,29 @@ get "/redirect/:count" do |env|
   count = env.params.url["count"].to_i
   env.response.headers["COUNT"] = count.to_s
   case count % 3
-  when 0
-    env.redirect "/redirect/#{count + 1}"
-  when 1
-    env.redirect "#{count + 1}"
-  when 2
-    env.redirect "http://0.0.0.0:3999/redirect/#{count + 1}"
+  when 0 then env.redirect "/redirect/#{count + 1}"
+  when 1 then env.redirect "#{count + 1}"
+  when 2 then env.redirect "http://0.0.0.0:3999/redirect/#{count + 1}"
+  end
+end
+
+get "/cookie" do |env|
+  cookie = env.request.headers["Cookie"]?
+
+  cookie ? "Cookie: #{cookie}" : "No cookie found"
+end
+
+put "/cookie" do |env|
+  cookie = env.params.query["cookie"]?
+  cookie ||= env.params.json["cookie"]? as String?
+  if cookie
+    cookie.split(";").each do |line|
+      next unless line.strip.size > 0
+      env.response.headers.add "Set-Cookie", line.strip
+    end
+    "Cookie set"
+  else
+    "No cookie given"
   end
 end
 

--- a/spec/unit/middleware/cookie_jar_middleware_spec.cr
+++ b/spec/unit/middleware/cookie_jar_middleware_spec.cr
@@ -1,0 +1,51 @@
+require "../../spec_helper"
+
+Spec2.describe Cossack::CookieJarMiddleware do
+  let(connection) { Cossack::TestConnection.new }
+  let(middleware) { Cossack::CookieJarMiddleware.new(connection) }
+  let(check_request) { Cossack::Request.new("GET", "http://example.com/abc/check_cookies") }
+  let(set_request) { Cossack::Request.new("GET", "http://example.com/abc/set_cookies") }
+
+  let(cookie) { HTTP::Cookie.new("foo", "bar") }
+
+  before do
+    connection.stub_get("http://example.com/abc/check_cookies", {
+      "Cookie" => cookie.to_cookie_header
+    }, {
+      200,
+      "OK"
+    })
+    connection.stub_get("http://example.com/abc/check_cookies", {
+      200,
+      "Not OK"
+    })
+    connection.stub_get("http://example.com/abc/set_cookies", {
+      200,
+      {
+        "Set-Cookie" => cookie.to_set_cookie_header
+      },
+      "OK"
+    })
+  end
+
+  it "has a cookie jar" do
+    expect(middleware.responds_to?(:cookie_jar)).to be_true
+  end
+
+  context "when cookie is in cookie jar" do
+    it "sets cookie request header" do
+      expect(middleware.call(check_request).body).to eq("Not OK")
+      middleware.cookie_jar << cookie
+      expect(middleware.call(check_request).body).to eq("OK")
+    end
+  end
+
+  context "when receiving set-cookie headers" do
+    it "sets the cookie in the cookie jar" do
+      expect(middleware.cookie_jar.has_key?(cookie.name)).to be_false
+      middleware.call(set_request)
+      expect(middleware.cookie_jar.has_key?(cookie.name)).to be_true
+      expect(middleware.cookie_jar[cookie.name].value).to eq(cookie.value)
+    end
+  end
+end

--- a/spec/unit/middleware/cookie_jar_middleware_spec.cr
+++ b/spec/unit/middleware/cookie_jar_middleware_spec.cr
@@ -2,7 +2,8 @@ require "../../spec_helper"
 
 Spec2.describe Cossack::CookieJarMiddleware do
   let(connection) { Cossack::TestConnection.new }
-  let(middleware) { Cossack::CookieJarMiddleware.new(connection) }
+  let(cookie_jar) { Cossack::CookieJar.new }
+  let(middleware) { Cossack::CookieJarMiddleware.new(connection, cookie_jar) }
   let(check_request) { Cossack::Request.new("GET", "http://example.com/abc/check_cookies") }
   let(set_request) { Cossack::Request.new("GET", "http://example.com/abc/set_cookies") }
 

--- a/src/cossack/client.cr
+++ b/src/cossack/client.cr
@@ -4,12 +4,14 @@ module Cossack
 
     @base_uri : URI
     @headers : HTTP::Headers
+    @cookies : CookieJar
     @app : Middleware|Connection|Proc(Request, Response)
 
-    getter :base_uri, :headers, :request_options, :connection
+    getter :base_uri, :headers, :request_options, :connection, :cookies
 
     def initialize(base_url = nil)
       @headers = default_headers
+      @cookies = CookieJar.new
       @request_options = RequestOptions.new
       @connection = HTTPConnection.new
       @app = @connection

--- a/src/cossack/cookie_jar.cr
+++ b/src/cossack/cookie_jar.cr
@@ -1,0 +1,46 @@
+require "http/cookie"
+require "http/headers"
+
+module Cossack
+  class CookieJar < HTTP::Cookies
+    def export_to_file(file_path : String)
+      # exports to Set-Cookie header values
+      headers = self.add_response_headers(HTTP::Headers.new)
+
+      File.open(file_path, "w") do |file|
+        headers.get("Set-Cookie").each { |line| file.puts line } unless headers.empty?
+      end
+    end
+
+    def self.from_file(file_path : String)
+      new.tap {|cj| cj.import_from_file(file_path) }
+    end
+
+    def import_from_file(file_path : String)
+      return self unless File.exists?(file_path)
+
+      # imports from Set-Cookie header values
+      tmp_headers = HTTP::Headers.new
+      File.each_line(file_path) do |line|
+        next unless line.strip.size == 0
+        tmp_headers.add("Set-Cookie", line.strip)
+      end
+
+      fill_from_headers(tmp_headers) unless tmp_headers.empty?
+    end
+
+    # OVERRIDE
+
+    def add_request_headers(headers)
+      super(headers) unless empty?
+
+      headers
+    end
+
+    def add_response_headers(headers)
+      super(headers) unless empty?
+
+      headers
+    end
+  end
+end

--- a/src/cossack/cookie_jar.cr
+++ b/src/cossack/cookie_jar.cr
@@ -3,6 +3,10 @@ require "http/headers"
 
 module Cossack
   class CookieJar < HTTP::Cookies
+    def self.from_file(file_path : String)
+      new.tap {|cj| cj.import_from_file(file_path) }
+    end
+
     def export_to_file(file_path : String)
       # exports to Set-Cookie header values
       headers = self.add_response_headers(HTTP::Headers.new)
@@ -10,10 +14,6 @@ module Cossack
       File.open(file_path, "w") do |file|
         headers.get("Set-Cookie").each { |line| file.puts line } unless headers.empty?
       end
-    end
-
-    def self.from_file(file_path : String)
-      new.tap {|cj| cj.import_from_file(file_path) }
     end
 
     def import_from_file(file_path : String)

--- a/src/cossack/cookie_jar.cr
+++ b/src/cossack/cookie_jar.cr
@@ -2,6 +2,10 @@ require "http/cookie"
 require "http/headers"
 
 module Cossack
+  # Stores cookies similar to HTTP::Cookies from Crystal's Std Library, but adds
+  # persistence methods in order to import/export to a file. The format is in
+  # Set-Cookie header style because Cookie headers lose information such as
+  # domain, http_only, and path restrictions
   class CookieJar < HTTP::Cookies
     def self.from_file(file_path : String)
       new.tap {|cj| cj.import_from_file(file_path) }
@@ -30,6 +34,10 @@ module Cossack
     end
 
     # OVERRIDE
+
+    # The methods below as they appear in the Std Library (as of v0.18.7) add a
+    # header that is blank if the cookie jar is empty instead of not adding any
+    # header at all.
 
     def add_request_headers(headers)
       super(headers) unless empty?

--- a/src/cossack/middleware/cookie_jar_middleware.cr
+++ b/src/cossack/middleware/cookie_jar_middleware.cr
@@ -1,0 +1,18 @@
+require "../cookie_jar"
+require "./middleware"
+
+module Cossack
+  class CookieJarMiddleware < Middleware
+    def call(request)
+      cookie_jar.add_request_headers(request.headers)
+      response = app.call(request)
+      cookie_jar.fill_from_headers(response.headers)
+
+      response
+    end
+
+    def cookie_jar
+      @cookie_jar ||= CookieJar.new
+    end
+  end
+end

--- a/src/cossack/middleware/cookie_jar_middleware.cr
+++ b/src/cossack/middleware/cookie_jar_middleware.cr
@@ -2,17 +2,28 @@ require "../cookie_jar"
 require "./middleware"
 
 module Cossack
+  # Stores persistent set of cookies
+  #
+  # ```
+  # cookies = CookieJar.new
+  # Cossack::Client.new do |client|
+  #   # store in cookie jar you provide
+  #   client.use Cossack::CookieJarMiddleware, cookie_jar: cookies
+  # end
+  # ```
+  #
   class CookieJarMiddleware < Middleware
+    getter :cookie_jar
+
+    def initialize(@app, @cookie_jar : CookieJar = CookieJar.new)
+    end
+
     def call(request)
       cookie_jar.add_request_headers(request.headers)
       response = app.call(request)
       cookie_jar.fill_from_headers(response.headers)
 
       response
-    end
-
-    def cookie_jar
-      @cookie_jar ||= CookieJar.new
     end
   end
 end


### PR DESCRIPTION
Not much to say. This is some middleware to allow cookies to persist between HTTP requests. Currently, it doesn't honor a lot of the constraints cookies require (e.g., path, expiration, http-only), but it does allow for tracking a persistent session.