### PR TITLE
Improve middleware sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Let's implement simple middleware that prints all requests:
 class StdoutLogMiddleware < Cossack::Middleware
   def call(request)
     puts "#{request.method} #{request.uri}"
-    response = app.call(request)
-    puts "Response: #{response.status} #{response.body}"
-    response
+    app.call(request).tap do |response|
+      puts "Response: #{response.status} #{response.body}"
+    end
   end
 end
 ```


### PR DESCRIPTION
Because [Object#tap](https://crystal-lang.org/api/0.18.7/Object.html#tap%28%26block%29-instance-method) gives a more elegant way to do this.