### PR TITLE
Ports deprecated 'x as Y' syntax (circa crystal v0.19.0) to 'x.as(Y)'

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,7 @@ license: LGPLv3
 development_dependencies:
   kemal:
     github: sdogruyol/kemal
+    version: ~> 0.15
   spec2:
-    github: greyblake/spec2.cr
-    branch: crystal-0-18-0
+    github: thelonelyghost/spec2.cr
+    branch: crystal-0-19-0

--- a/spec/support/server.cr
+++ b/spec/support/server.cr
@@ -51,7 +51,7 @@ end
 
 put "/cookie" do |env|
   cookie = env.params.query["cookie"]?
-  cookie ||= env.params.json["cookie"]? as String?
+  cookie ||= env.params.json["cookie"]?.as(String?)
   if cookie
     cookie.split(";").each do |line|
       next unless line.strip.size > 0

--- a/src/cossack/client.cr
+++ b/src/cossack/client.cr
@@ -54,7 +54,7 @@ module Cossack
 
         if params
           query = HTTP::Params.build do |form|
-            (params as Params).each { |name, val| form.add(name, val) }
+            (params.as(Params)).each { |name, val| form.add(name, val) }
           end
           if uri.query
             uri.query = [uri.query, query].join("&")


### PR DESCRIPTION
Addresses #6 with corrected syntax